### PR TITLE
Remove the deps we don't need for bip39

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -10,8 +10,6 @@ config("external_config") {
   defines = [ "USE_NUM_NONE", "USE_FIELD_10X26", "USE_FIELD_INV_BUILTIN", "USE_SCALAR_8X32", "USE_SCALAR_INV_BUILTIN", "ENABLE_MODULE_GENERATOR", "ENABLE_MODULE_RANGEPROOF", "ENABLE_MODULE_ECDH", "ENABLE_MODULE_SURJECTIONPROOF" ]
   include_dirs = [
     "include",
-    "src/secp256k1/include",
-    "src/secp256k1/src",
   ]
 }
 
@@ -27,27 +25,13 @@ source_set("bip39wally-core") {
   public_configs = [ ":external_config" ]
   configs += [ ":internal_config" ]
   sources = [
-    "src/aes.cc",
-    "src/base58.cc",
-    "src/bip32.cc",
-    "src/bip38.cc",
     "src/bip39.cc",
-    "src/bech32.cc",
-    "src/elements.cc",
-    "src/hextop.cc",
     "src/hmac.cc",
     "src/internal.cc",
     "src/mnemonic.cc",
     "src/pbkdf2.cc",
-    "src/script.cc",
-    "src/scrypt.cc",
-    "src/sign.cc",
-    "src/transaction.cc",
     "src/wordlist.cc",
-    "src/ccan/ccan/crypto/ripemd160/ripemd160.cc",
     "src/ccan/ccan/crypto/sha256/sha256.cc",
     "src/ccan/ccan/crypto/sha512/sha512.cc",
-    "src/ccan/ccan/str/hex/hex.cc",
-    "src/secp256k1/src/secp256k1.cc"
   ]
 }

--- a/src/internal.h
+++ b/src/internal.h
@@ -2,23 +2,8 @@
 #define LIBWALLY_INTERNAL_H
 
 #include "wally_core.h"
-#include "secp256k1/include/secp256k1.h"
 #include <config.h>
 #include <string.h>
-
-/* Fetch an internal secp context */
-const secp256k1_context *secp_ctx(void);
-#define secp256k1_context_destroy(c) _do_not_destroy_shared_ctx_pointers(c)
-
-#define pubkey_create     secp256k1_ec_pubkey_create
-#define pubkey_parse      secp256k1_ec_pubkey_parse
-#define pubkey_tweak_add  secp256k1_ec_pubkey_tweak_add
-#define pubkey_serialize  secp256k1_ec_pubkey_serialize
-#define privkey_tweak_add secp256k1_ec_privkey_tweak_add
-
-#define PUBKEY_COMPRESSED   SECP256K1_EC_COMPRESSED
-#define PUBKEY_UNCOMPRESSED SECP256K1_EC_UNCOMPRESSED
-
 
 void wally_clear(void *p, size_t len);
 void wally_clear_2(void *p, size_t len, void *p2, size_t len2);


### PR DESCRIPTION
We should only build what we would use, which is minimum dependency for the thing that bip39.cc really calls